### PR TITLE
chore(ci): fix renovate `rangeStrategy`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"],
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
Because renovate does not support pnpm-lock.json and cannot update the version.